### PR TITLE
Refactor Context usage for performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.0.8 (2019/7/10)
+
+- Performance improvements when mounting and unmounting large numbers of Focusable components.
+
 ### v0.0.7 (2019/7/10)
 
 - New `Focusable` props: `onBlur` and `onFocus`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xdproto/focus",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A React library for managing focus in TV apps",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/src/focus-root.js
+++ b/src/focus-root.js
@@ -1,57 +1,34 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import FocusContext from './focus-context';
 import createFocusTree from './focus-tree/create-focus-tree';
 import focusLrud from './focus-lrud/focus-lrud';
 
-function getFocusState(focusTreeRef) {
-  return {
-    ...focusTreeRef.current.getState(),
-    focusTree: focusTreeRef.current,
-    createNode: focusTreeRef.current.createNode,
-    updateNode: focusTreeRef.current.updateNode,
-    destroyNode: focusTreeRef.current.destroyNode,
-    setFocus: focusTreeRef.current.setFocus,
-  };
-}
-
 export default function FocusRoot({ children, orientation, wrapping }) {
-  const focusTreeRef = useRef();
-
-  if (!focusTreeRef.current) {
-    focusTreeRef.current = createFocusTree({
-      orientation,
-      wrapping,
-    });
-  }
-
-  const [focusState, setFocusState] = useState(() =>
-    getFocusState(focusTreeRef)
-  );
+  const [providerValue] = useState(() => {
+    return {
+      focusTree: createFocusTree({
+        orientation,
+        wrapping,
+      }),
+      currentNodeId: 'root',
+    };
+  });
 
   useEffect(() => {
-    // At this point in time, the focusOnMount component will have updated the focus tree. But –
-    // we haven't subscribed, so our mirrored state is stale. We manually sync it.
-    setFocusState(getFocusState(focusTreeRef));
-
-    // Now that we've manually synced the state, we can set up an automatic subscription to keep the state in order
-    // going forward.
-    const unsubscribe = focusTreeRef.current.subscribe(() =>
-      setFocusState(getFocusState(focusTreeRef))
-    );
-
-    const lrud = focusLrud(focusTreeRef.current);
+    window.focusTree = providerValue.focusTree;
+    const lrud = focusLrud(providerValue.focusTree);
     lrud.subscribe();
 
     return () => {
-      unsubscribe();
       lrud.unsubscribe();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return React.createElement(
     FocusContext.Provider,
-    { value: focusState },
+    { value: providerValue },
     children
   );
 }

--- a/src/focus-root.js
+++ b/src/focus-root.js
@@ -16,7 +16,6 @@ export default function FocusRoot({ children, orientation, wrapping }) {
   });
 
   useEffect(() => {
-    window.focusTree = providerValue.focusTree;
     const lrud = focusLrud(providerValue.focusTree);
     lrud.subscribe();
 

--- a/src/focusable.js
+++ b/src/focusable.js
@@ -153,6 +153,10 @@ export function Focusable(
       const newNode = state.nodes[idRef.current] || focusNodeRef.current;
 
       if (checkIfUpdateIsNecessary(newNode, focusNodeRef.current)) {
+        // This ref is updated whenever `setNode` resolves, but there can be a delay
+        // between when that occurs. For that reason, we manually update it here to
+        // ensure that subsequent calls are using the _actual_ up-to-date node.
+        focusNodeRef.current = newNode;
         setNode(newNode);
       }
     });

--- a/src/focusable.js
+++ b/src/focusable.js
@@ -12,6 +12,14 @@ import FocusContext from './focus-context';
 
 let uniqueValue = 0;
 
+// Presently, the only impact a focus node has on the DOM is related to:
+//
+//   - isFocused
+//   - isFocusedExact
+//   - disabled
+//
+// through the form of the class names. Therefore, we only update the state
+// when one of these attributes change.
 function checkIfUpdateIsNecessary(one = {}, two = {}) {
   const focusChanged = Boolean(one.isFocused) !== Boolean(two.isFocused);
   const focusExactChanged =

--- a/src/focusable.js
+++ b/src/focusable.js
@@ -160,6 +160,7 @@ export function Focusable(
     return () => {
       unsubscribe();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const { isFocused, isFocusedExact } = node;

--- a/src/hooks/use-current-ref.js
+++ b/src/hooks/use-current-ref.js
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react';
+
+export default function useCurrentRef(value) {
+  const currentRef = useRef(value);
+
+  useEffect(() => {
+    currentRef.current = value;
+  }, [value]);
+
+  return currentRef;
+}

--- a/src/use-is-focused.js
+++ b/src/use-is-focused.js
@@ -2,14 +2,46 @@ import { useState, useContext, useEffect } from 'react';
 import FocusContext from './focus-context';
 
 export default function useIsFocused(focusId, { exact = false } = {}) {
-  const [isFocused, setIsFocused] = useState(false);
-  const { nodes } = useContext(FocusContext);
+  // The tree never changes, so a ref is unnecessary
+  const { focusTree } = useContext(FocusContext);
+
+  const [isFocused, setIsFocused] = useState(() => {
+    const currentState = focusTree.getState();
+    const node = currentState.nodes[focusId] || {};
+    const focusState = exact ? node.isFocusedExact : node.isFocused;
+
+    return Boolean(focusState);
+  });
 
   useEffect(() => {
-    const node = nodes[focusId] || {};
-    const focusState = exact ? node.isFocusedExact : node.isFocused;
-    setIsFocused(Boolean(focusState));
-  }, [setIsFocused, nodes, exact, focusId]);
+    const currentState = focusTree.getState();
+    let currentNode = currentState.nodes[focusId] || {};
+    let currentFocusState = exact
+      ? currentNode.isFocusedExact
+      : currentNode.isFocused;
+
+    // Just in case the mounting of the component changes the focus state.
+    if (isFocused !== currentFocusState) {
+      setIsFocused(Boolean(currentFocusState));
+    }
+
+    const unsubscribe = focusTree.subscribe(() => {
+      const state = focusTree.getState();
+      const node = state.nodes[focusId] || {};
+      const focusState = exact ? node.isFocusedExact : node.isFocused;
+
+      if (Boolean(focusState) !== Boolean(currentFocusState)) {
+        currentNode = node;
+        currentFocusState = focusState;
+        setIsFocused(Boolean(focusState));
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return isFocused;
 }

--- a/src/use-set-focus.js
+++ b/src/use-set-focus.js
@@ -2,7 +2,6 @@ import { useContext } from 'react';
 import FocusContext from './focus-context';
 
 export default function useSetFocus() {
-  const { setFocus } = useContext(FocusContext);
-
-  return setFocus;
+  const { focusTree } = useContext(FocusContext);
+  return focusTree.setFocus;
 }


### PR DESCRIPTION
Resolves #21 

**The problem**

The old implementation propagated changes through Context. This was problematic in situations where there were a lot of focused nodes: any change to the focus tree would rerender every subscribed component.

I was observing noticeable drops in performance due to this problem.

**This solution**

In this solution, Context never causes a rerender, because the Context values are always static.

Instead, localized state causes a render. This state is kept in sync using `focusTree.subscribe()`. To ensure that the fewest number of things render at a time, a comparison check is utilized in the subscribe callback to see if state should be synchronized.

**Additional work**

It would probably be worthwhile to refactor the `Focusable` in a more substantial way. Perhaps I'll do that when I work on #25 

**Alternative solutions**

Context selectors is an alternative solution, but as of the time of writing they are only an RFC.